### PR TITLE
Fix: Resolve TypeError in image captions

### DIFF
--- a/src/components/editor/plugins/media-plugins.tsx
+++ b/src/components/editor/plugins/media-plugins.tsx
@@ -4,7 +4,7 @@ import { CaptionPlugin } from '@udecode/plate-caption/react';
 import {
   AudioPlugin,
   FilePlugin,
-  ImagePlugin,
+  ImagePlugin as BaseImagePlugin, // Renamed import
   MediaEmbedPlugin,
   PlaceholderPlugin,
   VideoPlugin,
@@ -13,11 +13,20 @@ import {
 import { ImagePreview } from '@/components/ui/image-preview';
 import { MediaUploadToast } from '@/components/ui/media-upload-toast';
 
+// 1. Create the extended plugin and store it in a variable
+const ExtendedImagePlugin = BaseImagePlugin.extend({
+  options: {
+    disableUploadInsert: true,
+    props: {
+      caption: [{ type: 'p', children: [{ text: '' }] }],
+    },
+  },
+  render: { afterEditable: ImagePreview }, // Ensure render config is kept
+});
+
 export const mediaPlugins = [
-  ImagePlugin.extend({
-    options: { disableUploadInsert: true },
-    render: { afterEditable: ImagePreview },
-  }),
+  // 2. Use the variable in the mediaPlugins array
+  ExtendedImagePlugin,
   MediaEmbedPlugin,
   VideoPlugin,
   AudioPlugin,
@@ -25,7 +34,8 @@ export const mediaPlugins = [
   CaptionPlugin.configure({
     options: {
       plugins: [
-        ImagePlugin,
+        // 3. Use the variable in CaptionPlugin's configuration
+        ExtendedImagePlugin,
         VideoPlugin,
         AudioPlugin,
         FilePlugin,

--- a/src/components/ui/image-element.tsx
+++ b/src/components/ui/image-element.tsx
@@ -104,19 +104,7 @@ export const ImageElement = withHOC(
             <Caption style={{ width }} align={align}>
               <CaptionTextarea
                 readOnly={readOnly}
-                onFocus={(e) => {
-                  e.preventDefault();
-                }}
                 placeholder="Write a caption..."
-                onBlur={(e) => {
-                  if (!readOnly && e.target.textContent) {
-                    // Usamos casting para evitar error de tipo
-                    (editor as any).setNodes(
-                      { caption: e.target.textContent },
-                      { at: (editor as any).findPath(props.element) }
-                    );
-                  }
-                }}
               />
             </Caption>
           </figure>

--- a/src/components/ui/media-toolbar-button.tsx
+++ b/src/components/ui/media-toolbar-button.tsx
@@ -182,12 +182,16 @@ function MediaUrlDialogContent({
     if (!isUrl(url)) return toast.error('Invalid URL');
 
     setOpen(false);
-    editor.tf.insertNodes({
+    const nodeData: any = {
       children: [{ text: '' }],
       name: nodeType === FilePlugin.key ? url.split('/').pop() : undefined,
       type: nodeType,
       url,
-    });
+    };
+    if (nodeType === ImagePlugin.key) {
+      nodeData.caption = [{ type: 'p', children: [{ text: '' }] }];
+    }
+    editor.tf.insertNodes(nodeData);
   }, [url, editor, nodeType, setOpen]);
 
   return (


### PR DESCRIPTION
Addresses a "Cannot read properties of undefined (reading 'map')" error that occurred when adding or interacting with captions for images in the Plate editor.

The fix involves several key changes:
1.  Standardized Caption Handling: Modified `ImageElement.tsx` to ensure captions are treated as an array of Slate `TDescendant` nodes, aligning with Plate.js conventions, instead of plain strings.
2.  Correct Caption Initialization: Ensured that the `caption` field on image nodes is initialized as a valid empty Slate node array (e.g., `[{ type: 'p', children: [{ text: '' }] }]`) upon insertion, both for images added via URL and via file upload. This was achieved by modifying `media-toolbar-button.tsx` and the `ImagePlugin` configuration in `media-plugins.tsx`.
3.  Correct Plugin Configuration: Updated `media-plugins.tsx` to ensure that `CaptionPlugin` is configured with the *extended* version of `ImagePlugin`. This extended version now includes the default caption structure, making it visible to `CaptionPlugin` and preventing errors caused by mismatched plugin configurations.

These changes ensure that the captioning system has the correct data structures and plugin configurations it expects, preventing the runtime error.