### PR TITLE
Fix: Resolve AdSense warning and hardcode client ID

### DIFF
--- a/apphosting.yaml
+++ b/apphosting.yaml
@@ -6,8 +6,7 @@ runConfig:
   # concurrency: 80
   # cpu: 1
   # memoryMiB: 512
-  environmentVariables:
-    NEXT_PUBLIC_GOOGLE_ADS_CLIENT_ID: 'ca-pub-6483322960648315'
+  environmentVariables: {}
 
 # Environment variables and secrets.
 env:

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -26,12 +26,11 @@ export default function RootLayout({
           async
           src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"
         ></script>
-        <Script
+        <script
           async
-          src={`https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=${process.env.NEXT_PUBLIC_GOOGLE_ADS_CLIENT_ID}`}
-          strategy="afterInteractive"
+          src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-6483322960648315"
           crossOrigin="anonymous"
-        />
+        ></script>
       </head>
       <body className={inter.className}>
         <ThemeProvider

--- a/src/components/custom/AdBanner.tsx
+++ b/src/components/custom/AdBanner.tsx
@@ -42,7 +42,7 @@ const AdBanner: React.FC<AdBannerProps> = ({
       <ins
         className="adsbygoogle"
         style={style}
-        data-ad-client={process.env.NEXT_PUBLIC_GOOGLE_ADS_CLIENT_ID} // Will pick up var from apphosting.yaml
+        data-ad-client="ca-pub-6483322960648315"
         data-ad-slot={dataAdSlot}
         data-ad-format={dataAdFormat}
         data-full-width-responsive={dataFullWidthResponsive?.toString()}


### PR DESCRIPTION
Addresses an AdSense console warning "head tag doesn't support data-nscript attribute" by changing the AdSense script in `src/app/layout.tsx` from a Next.js `Script` component to a standard HTML `<script>` tag.

This change also hardcodes the AdSense client ID `ca-pub-6483322960648315` directly into:
- The AdSense script URL in `src/app/layout.tsx`.
- The `data-ad-client` attribute in `src/components/custom/AdBanner.tsx`.

The corresponding environment variable `NEXT_PUBLIC_GOOGLE_ADS_CLIENT_ID` has been removed from `apphosting.yaml` as it's no longer needed.