### PR TITLE
Fix typo in image preview comment

### DIFF
--- a/src/components/ui/image-preview.tsx
+++ b/src/components/ui/image-preview.tsx
@@ -127,7 +127,7 @@ export const ImagePreview = () => {
                 <Plus className="size-4" />
               </button>
             </div>
-            {/* TODO: downLoad the image */}
+            {/* TODO: download the image */}
             <button className={cn(toolButtonVariants())} type="button">
               <Download className="size-4" />
             </button>


### PR DESCRIPTION
## Summary
- fix casing of download comment in `ImagePreview`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f853d504c8331804863d7da9b5526