### PR TITLE
Fix: Agregar scroll vertical a la barra lateral de administración

### DIFF
--- a/src/components/admin/AdminSidebar.tsx
+++ b/src/components/admin/AdminSidebar.tsx
@@ -55,7 +55,7 @@ export const AdminSidebar: React.FC = () => {
         </Button>
       </div>
       
-      <nav className="space-y-2 flex-1">
+      <nav className="space-y-2 flex-1 overflow-y-auto min-h-0">
         <SidebarItem 
           href="/admin/dashboard" 
           icon={<Home size={18} />} 


### PR DESCRIPTION
Observé que cuando el árbol de carpetas o elementos de menú en la barra lateral de administración es muy extenso y despliegas múltiples niveles, el contenido excede la altura visible de la pantalla, impidiendo el acceso a los elementos inferiores debido a la ausencia de una barra de desplazamiento.

Este cambio aborda el problema modificando el componente `AdminSidebar.tsx`. He añadido la clase `overflow-y-auto` y `min-h-0` al tag `<nav>` que envuelve los elementos de navegación. Esto permite que aparezca una barra de desplazamiento vertical cuando el contenido del menú exceda la altura disponible en la pantalla, asegurando que todos los elementos sean accesibles.

La propiedad `flex-1` existente en el tag `<nav>`, combinada con `min-h-0` y las propiedades flex del contenedor padre, aseguran que el área de navegación se restrinja correctamente en altura, permitiendo que `overflow-y-auto` funcione como se espera.

Verifiqué conceptualmente que este cambio no afecta negativamente la funcionalidad de los componentes recursivos (`RecursiveFileItem.tsx` y `RecursiveMenuItem.tsx`) que utilizas para renderizar las estructuras de árbol dentro de la barra lateral.