### PR TITLE
feat: Agregar scroll vertical al menú de carpetas anidadas

### DIFF
--- a/src/components/admin/RecursiveMenuItem.tsx
+++ b/src/components/admin/RecursiveMenuItem.tsx
@@ -134,7 +134,7 @@ export const RecursiveMenuItem = ({
                   ref={provided.innerRef}
                   {...provided.droppableProps}
                   className={cn(
-                    "pl-4 ml-6 border-l mt-1",
+                    "pl-4 ml-6 border-l mt-1 overflow-y-auto max-h-[calc(100vh-20rem)]",
                     snapshot.isDraggingOver && "border-primary"
                   )}
                 >


### PR DESCRIPTION
Se agrega la funcionalidad de scroll vertical al componente RecursiveMenuItem utilizando las clases `overflow-y-auto` y `max-h-[calc(100vh-20rem)]` de Tailwind CSS.

Esto soluciona el problema donde los elementos inferiores del menú no eran accesibles cuando el árbol de carpetas era muy extenso y excedía la altura visible de la pantalla.

La modificación se realizó en el 'div' que envuelve a los elementos hijos de una carpeta dentro de `src/components/admin/RecursiveMenuItem.tsx`.